### PR TITLE
Convert to use .NET Standard 2.0

### DIFF
--- a/ArkEcosystem.Client/ArkEcosystem.Client.csproj
+++ b/ArkEcosystem.Client/ArkEcosystem.Client.csproj
@@ -1,7 +1,7 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <PackOnBuild>true</PackOnBuild>
     <PackageVersion>0.1.0</PackageVersion>
     <PackageLicenseUrl>https://github.com/ArkEcosystem/dotnet-client/blob/master/LICENSE</PackageLicenseUrl>


### PR DESCRIPTION
## Proposed changes

Converts the dotnet-client library to use the .NET Standard 2.0 to enable any compatible framework (.NET Core, .NET Full Framework, Unity) to consume it.

This also matches what dotnet-crypto does.

## Types of changes

What types of changes does your code introduce?
_Put an `x` in the boxes that apply_

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Refactoring (improve a current implementation without adding a new feature or fixing a bug)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Build (changes that affect the build system)
- [ ] Docs (documentation only changes)
- [ ] Test (adding missing tests or fixing existing tests)
- [ ] Other... Please describe:

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

- [x] I have read the [CONTRIBUTING](https://docs.ark.io/docs/contributing) documentation
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)

## Further comments

This is a small code change but potentially large environment change.  I think it is an improvement as it provides more flexibility but I want to make sure I'm not missing anything.  It is open for discussion.

Fixes #8 