### PR TITLE
fix: add covariant connection interface

### DIFF
--- a/ArkEcosystem.Client.Tests/ConnectionManagerTest.cs
+++ b/ArkEcosystem.Client.Tests/ConnectionManagerTest.cs
@@ -1,0 +1,112 @@
+// Author:
+//       Brian Faust <brian@ark.io>
+//
+// Copyright (c) 2018 Ark Ecosystem <info@ark.io>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace ArkEcosystem.Client.Tests
+{
+    [TestClass]
+    public class ConnectionManagerTest
+    {
+        [TestMethod]
+        public void Should_Create_A_Connection()
+        {
+            var manager = new ConnectionManager();
+            var conn = TestHelper.MockConnection<ArkEcosystem.Client.API.One.One>();
+            manager.Connect(conn, "test");
+            CollectionAssert.Contains(manager.GetConnections().Keys, "test");
+        }
+
+        [TestMethod]
+        public void Should_Throw_If_A_Connection_Already_Exists()
+        {
+            var manager = new ConnectionManager();
+            var conn = TestHelper.MockConnection<ArkEcosystem.Client.API.One.One>();
+            manager.Connect(conn, "test");
+            Assert.ThrowsException<Exception>(() => manager.Connect(conn, "test"));
+        }
+
+        [TestMethod]
+        public void Should_Remove_A_Connection()
+        {
+            var manager = new ConnectionManager();
+            var conn = TestHelper.MockConnection<ArkEcosystem.Client.API.One.One>();
+            manager.Connect(conn, "test");
+            CollectionAssert.Contains(manager.GetConnections().Keys, "test");
+            manager.Disconnect("test");
+            CollectionAssert.DoesNotContain(manager.GetConnections().Keys, "test");
+        }
+
+
+        [TestMethod]
+        public void Should_Return_A_Connection()
+        {
+            var manager = new ConnectionManager();
+            var conn = TestHelper.MockConnection<ArkEcosystem.Client.API.One.One>();
+            manager.Connect(conn, "test");
+            Assert.IsInstanceOfType(manager.Connection<ArkEcosystem.Client.API.One.One>("test"), typeof(Connection<ArkEcosystem.Client.API.One.One>));
+        }
+
+        [TestMethod]
+        public void Should_Throw_If_A_Connection_Does_Not_Exist()
+        {
+            var manager = new ConnectionManager();
+            Assert.ThrowsException<KeyNotFoundException>(() => manager.Connection<ArkEcosystem.Client.API.One.One>("main"));
+        }
+
+        [TestMethod]
+        public void Should_Return_The_Default_Connection()
+        {
+            var manager = new ConnectionManager();
+            Assert.AreEqual(manager.GetDefaultConnection(), "main");
+        }
+
+        [TestMethod]
+        public void Should_Set_The_Default_Connection()
+        {
+            var manager = new ConnectionManager();
+            manager.SetDefaultConnection("test");
+            Assert.AreEqual(manager.GetDefaultConnection(), "test");
+        }
+
+        [TestMethod]
+        public void Should_Return_All_Connections()
+        {
+            var manager = new ConnectionManager();
+            var conn1 = TestHelper.MockConnection<ArkEcosystem.Client.API.One.One>();
+            var conn2 = TestHelper.MockConnection<ArkEcosystem.Client.API.Two.Two>();
+            var conn3 = TestHelper.MockConnection<ArkEcosystem.Client.API.One.One>();
+
+            manager.Connect(conn1, "test1");
+            manager.Connect(conn2, "test2");
+            manager.Connect(conn3, "test3");
+
+            Assert.AreEqual(manager.GetConnections().Count, 3);
+            CollectionAssert.AreEqual(manager.GetConnections().Values, new List<IConnection<ArkEcosystem.Client.API.Api>>() {
+                conn1, conn2, conn3
+            });
+        }
+    }
+}

--- a/ArkEcosystem.Client.Tests/TestHelper.cs
+++ b/ArkEcosystem.Client.Tests/TestHelper.cs
@@ -35,7 +35,7 @@ namespace ArkEcosystem.Client.Tests
         const string MOCK_HOST = "https://127.0.0.1:4003/api/";
         const string FIXTURES_PATH = "../../../Fixtures/";
 
-        static MockHttpMessageHandler mockHttp;
+        static MockHttpMessageHandler mockHttp = new MockHttpMessageHandler();
 
         public static MockedRequest MockHttpRequestOne(string path)
         {
@@ -59,7 +59,7 @@ namespace ArkEcosystem.Client.Tests
                 .Respond("application/json", fixture);
         }
 
-        public static Connection<T> MockConnection<T>() where T : Api
+        public static IConnection<T> MockConnection<T>() where T : Api
         {
             var client = mockHttp.ToHttpClient();
             client.BaseAddress = new Uri(MOCK_HOST);

--- a/ArkEcosystem.Client/Connection.cs
+++ b/ArkEcosystem.Client/Connection.cs
@@ -4,7 +4,12 @@ using ArkEcosystem.Client.API;
 
 namespace ArkEcosystem.Client
 {
-    public sealed class Connection<T> where T : Api
+    public interface IConnection<out T> where T : Api {
+        T Api { get; }
+        HttpClient Client { get; }
+    }
+
+    public sealed class Connection<T> : IConnection<T> where T: Api
     {
         public HttpClient Client { get; }
 

--- a/ArkEcosystem.Client/ConnectionManager.cs
+++ b/ArkEcosystem.Client/ConnectionManager.cs
@@ -20,6 +20,7 @@
 // LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
+using System;
 using System.Collections.Generic;
 using ArkEcosystem.Client.API;
 
@@ -33,6 +34,10 @@ namespace ArkEcosystem.Client
 
         public IConnection<T> Connect<T>(IConnection<T> connection, string name = "main") where T : Api
         {
+            if (connections.ContainsKey(name)) {
+                throw new Exception(string.Format("Connection '{0}' already exists.", name));
+            }
+
             connections[name] = connection as IConnection<Api>;
             return connection;
         }

--- a/ArkEcosystem.Client/ConnectionManager.cs
+++ b/ArkEcosystem.Client/ConnectionManager.cs
@@ -29,11 +29,11 @@ namespace ArkEcosystem.Client
     {
         string defaultConnection = "main";
 
-        readonly Dictionary<string, Connection<Api>> connections = new Dictionary<string, Connection<Api>>();
+        readonly Dictionary<string, IConnection<Api>> connections = new Dictionary<string, IConnection<Api>>();
 
-        public Connection<T> Connect<T>(Connection<T> connection, string name = "main") where T : Api
+        public IConnection<T> Connect<T>(IConnection<T> connection, string name = "main") where T : Api
         {
-            connections[name] = connection as Connection<Api>;
+            connections[name] = connection as IConnection<Api>;
             return connection;
         }
 
@@ -42,9 +42,9 @@ namespace ArkEcosystem.Client
             connections.Remove(name ?? GetDefaultConnection());
         }
 
-        public Connection<T> Connection<T>(string name = null) where T : Api
+        public IConnection<T> Connection<T>(string name = null) where T : Api
         {
-            return connections[name ?? GetDefaultConnection()] as Connection<T>;
+            return connections[name ?? GetDefaultConnection()] as IConnection<T>;
         }
 
         public string GetDefaultConnection()
@@ -57,7 +57,7 @@ namespace ArkEcosystem.Client
             defaultConnection = name;
         }
 
-        public Dictionary<string, Connection<Api>> GetConnections()
+        public Dictionary<string, IConnection<Api>> GetConnections()
         {
             return connections;
         }


### PR DESCRIPTION
Fixes #11.

By adding a covariant connection interface, the ConnectionManager can correctly cast `Connection<T>` to `Connection<base class of T>`.

Will add tests next.